### PR TITLE
Initial AWS cluster spec

### DIFF
--- a/custom_object.go
+++ b/custom_object.go
@@ -1,0 +1,12 @@
+package awsclusterspec
+
+import (
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+type CustomObject struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Spec                 Spec `json:"spec"`
+}

--- a/spec.go
+++ b/spec.go
@@ -1,0 +1,37 @@
+package awsclusterspec
+
+type Spec struct {
+	Customer   string                `json:"customer"`
+	ClusterID  string                `json:"clusterId"`
+	Kubernetes kubernetes.Kubernetes `json:"kubernetes"`
+
+	K8sVersion     string `json:"k8sVersion"`
+	KubectlVersion string `json:"kubectlVersion"`
+
+	Master Master `json:"master"`
+	Worker Worker `json:"worker"`
+}
+
+type Master struct {
+	Kubernetes Kubernetes `json:"kubernetes"`
+	Machine
+}
+
+type Worker struct {
+	Kubernetes Kubernetes `json:"kubernetes"`
+	Machine
+}
+
+type Kubernetes struct {
+	DnsIP            string `json:"dnsIP"`
+	Domain           string `json:"domain"`
+	EtcdDomainName   string `json:"etcdDomainName"`
+	MasterDomainName string `json:"masterDomainName"`
+	InsecurePort     string `json:"insecurePort"`
+	SecurePort       string `json:"securePort"`
+}
+
+type Machine struct {
+	InstanceType string `json:"instanceType"`
+	Replicas     int    `json:"replicas"`
+}


### PR DESCRIPTION
This is a cluster specification which will be user by aws-operator and the main difference between it and the clusterspec used by cluster controller is a bigger focus on AWS-specific parameters and lack of flannel options for VM networking.

Ref https://github.com/giantswarm/giantswarm/issues/1198