### PR TITLE
Define a VPC struct with CIDRs for subnets

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1,8 +1,11 @@
 package aws
 
+import "github.com/giantswarm/awstpr/aws/vpc"
+
 type AWS struct {
-	Masters []Node `json:"masters" yaml:"masters"`
-	Region  string `json:"region" yaml:"region"`
-	AZ      string `json:"az" yaml:"az"`
-	Workers []Node `json:"workers" yaml:"workers"`
+	Masters []Node  `json:"masters" yaml:"masters"`
+	Workers []Node  `json:"workers" yaml:"workers"`
+	Region  string  `json:"region" yaml:"region"`
+	AZ      string  `json:"az" yaml:"az"`
+	VPC     vpc.VPC `json:"vpc" yaml:"vpc"`
 }

--- a/aws/vpc/vpc.go
+++ b/aws/vpc/vpc.go
@@ -1,0 +1,7 @@
+package vpc
+
+type VPC struct {
+	CIDR              string `json:"cidr" yaml:"cidr"`
+	PrivateSubnetCIDR string `json:"privateSubnetCidr" yaml:"privateSubnetCidr"`
+	PublicSubnetCIDR  string `json:"publicSubnetCidr" yaml:"publicSubnetCidr"`
+}


### PR DESCRIPTION
Closes https://github.com/giantswarm/awstpr/issues/17.

It would look like this in the TPO:

```yaml
  aws:
    region: "eu-central-1"
    az: "eu-central-1a"
    vpc:
      cidr: "10.0.0.0/16"
      privateSubnetCidr: "10.0.0.0/19"
      publicSubnetCidr: "10.0.128.0/20"
```