### PR TITLE
Add PluralKind for use in resource URLs

### DIFF
--- a/kind.go
+++ b/kind.go
@@ -5,5 +5,5 @@ const (
 	Kind = "Aws"
 
 	// PluralKind is the plural TPR kind for use in resource URLs.
-	PluralKind = "Awses"
+	PluralKind = "awses"
 )

--- a/kind.go
+++ b/kind.go
@@ -3,4 +3,7 @@ package awstpr
 const (
 	// Kind is the TPR kind for awstpr resources.
 	Kind = "Aws"
+
+	// PluralKind is the plural TPR kind for use in resource URLs.
+	PluralKind = "Awses"
 )


### PR DESCRIPTION
This PR adds the plural kind because the plural of aws is awses which is irregular.