### PR TITLE
Add a field for Docker image for amazon-ssm-agent

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/giantswarm/awstpr/aws/hostedzones"
+	"github.com/giantswarm/awstpr/aws/ssm"
 	"github.com/giantswarm/awstpr/aws/vpc"
 )
 
@@ -11,5 +12,6 @@ type AWS struct {
 	Region      string                  `json:"region" yaml:"region"`
 	AZ          string                  `json:"az" yaml:"az"`
 	HostedZones hostedzones.HostedZones `json:"hostedZones" yaml:"hostedZones"`
+	SSMAgent    ssm.SSMAgent            `json:"ssmAgent" yaml:"ssmAgent"`
 	VPC         vpc.VPC                 `json:"vpc" yaml:"vpc"`
 }

--- a/aws/ssm/docker/docker.go
+++ b/aws/ssm/docker/docker.go
@@ -1,0 +1,7 @@
+package docker
+
+type Docker struct {
+	// Image is the full qualified docker image.
+	// e.g. rlister/amazon-ssm-agent
+	Image string `json:"image" yaml:"image"`
+}

--- a/aws/ssm/ssm.go
+++ b/aws/ssm/ssm.go
@@ -1,0 +1,9 @@
+package ssm
+
+import (
+	"github.com/giantswarm/awstpr/aws/ssm/docker"
+)
+
+type SSMAgent struct {
+	Docker docker.Docker `json:"docker" yaml:"docker"`
+}


### PR DESCRIPTION
In order to use AWS autoscaling properly, we need to use amazon-ssm-agent on our nodes. The best way to do that on CoreOS is to run it as a container.

Ref giantswarm/aws-operator#258