### PR TITLE
Add version bundle

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Spec struct {
-	Cluster clustertpr.Spec `json:"cluster" yaml:"cluster"`
-	AWS     spec.AWS        `json:"aws" yaml:"aws"`
+	Cluster       clustertpr.Spec    `json:"cluster" yaml:"cluster"`
+	AWS           spec.AWS           `json:"aws" yaml:"aws"`
+	VersionBundle spec.VersionBundle `json:"versionBundle" yaml:"versionBundle"`
 }

--- a/spec/version_bundle.go
+++ b/spec/version_bundle.go
@@ -1,0 +1,5 @@
+package spec
+
+type VersionBundle struct {
+	Version string `json:"version" yaml:"version"`
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -164,6 +164,9 @@ func TestSpecYamlEncoding(t *testing.T) {
 				},
 			},
 		},
+		VersionBundle: spec.VersionBundle{
+			Version: "0.1.0",
+		},
 	}
 
 	var got map[string]interface{}

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -91,3 +91,5 @@ aws:
     instanceType: m3.large
   - imageID: ami-d60ad6b9
     instanceType: m3.large
+versionBundle:
+  version: 0.1.0


### PR DESCRIPTION
Towards giantswarm/giantswarm#2023

Adds version bundle so we can do resource routing in aws-operator.